### PR TITLE
Adding getBaseShares() support

### DIFF
--- a/contracts/interfaces/IOKLGRewardDistributor.sol
+++ b/contracts/interfaces/IOKLGRewardDistributor.sol
@@ -6,6 +6,8 @@ interface IOKLGRewardDistributor {
 
   function getShares(address wallet) external view returns (uint256);
 
+  function getBaseShares(address wallet) external view returns (uint256);
+
   function getBoostNfts(address wallet)
     external
     view


### PR DESCRIPTION
getBaseShares() will be required for use in proxyOKLG.sol